### PR TITLE
feat(ui): Display 'View in Github' if externalUrl is link to GitHub

### DIFF
--- a/datahub-web-react/src/app/entity/shared/ExternalUrlButton.tsx
+++ b/datahub-web-react/src/app/entity/shared/ExternalUrlButton.tsx
@@ -5,6 +5,8 @@ import UrlButton from './UrlButton';
 
 const GITHUB_LINK = 'github.com';
 const GITHUB = 'GitHub';
+const GITLAB_LINK = 'gitlab.com';
+const GITHUB = 'GitLab';
 
 interface Props {
     externalUrl: string;
@@ -26,6 +28,8 @@ export default function ExternalUrlButton({ externalUrl, platformName, entityTyp
     let displayedName = platformName;
     if (externalUrl.toLocaleLowerCase().includes(GITHUB_LINK)) {
         displayedName = GITHUB;
+    } else if (externalUrl.toLocaleLowerCase().includes(GITLAB_LINK)) {
+        displayedName = GITLAB;
     }
 
     return (


### PR DESCRIPTION
## Checklist

Currently, if github links are present the "View in .. " button gets changed to "View in Github". However, if there are gitlab links are present, it still points to the platform name. So for example, if the platform is Looker, even though there is a gitlab link present, it shows "View in Looker" in the UI. If you click on it, it goes to the Gitlab page. 

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
